### PR TITLE
Fixes for Login, Register, Home, and WeightHistory screens

### DIFF
--- a/app/src/main/java/com/example/happ_frontend/model/weight/communication/WeightHistoryNetworkModule.kt
+++ b/app/src/main/java/com/example/happ_frontend/model/weight/communication/WeightHistoryNetworkModule.kt
@@ -1,5 +1,6 @@
 package com.example.happ_frontend.model.weight.communication
 
+import android.util.Log
 import androidx.compose.ui.Modifier
 import com.example.happ_frontend.model.login_register.communication.AuthApiService
 import com.example.happ_frontend.model.login_register.communication.AuthNetworkModule
@@ -30,6 +31,10 @@ object WeightHistoryNetworkModule {
             val jwt = AuthSharedPreferencesProvider.editor?.jwt
             val request = chain.request().newBuilder()
                 .let {
+                    Log.d(
+                        "WeightHistoryNetworkModule (request builder)",
+                        "jwt: ${jwt}"
+                    )
                     if (jwt != null)
                         it.addHeader("Authorization", "Bearer $jwt")
                     else it

--- a/app/src/main/java/com/example/happ_frontend/model/weight/communication/WeightHistoryNetworkModule.kt
+++ b/app/src/main/java/com/example/happ_frontend/model/weight/communication/WeightHistoryNetworkModule.kt
@@ -1,9 +1,7 @@
 package com.example.happ_frontend.model.weight.communication
 
 import android.util.Log
-import androidx.compose.ui.Modifier
 import com.example.happ_frontend.model.login_register.communication.AuthApiService
-import com.example.happ_frontend.model.login_register.communication.AuthNetworkModule
 import com.example.happ_frontend.model.login_register.data.AuthSharedPreferencesProvider
 import com.example.happ_frontend.model.login_register.serialization.LocalDateAdapter
 import com.example.happ_frontend.model.login_register.serialization.LocalDateTimeAdapter

--- a/app/src/main/java/com/example/happ_frontend/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/AppViewModelProvider.kt
@@ -1,17 +1,15 @@
 package com.example.happ_frontend.ui
 
-import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.happ_frontend.HappFrontendApplication
-import com.example.happ_frontend.ui.domain.notifications.NotificationViewModel
-import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import com.example.happ_frontend.model.login_register.communication.AuthNetworkModule
-import com.example.happ_frontend.model.login_register.data.AuthSharedPreferencesEditor
 import com.example.happ_frontend.model.weight.communication.WeightHistoryNetworkModule
 import com.example.happ_frontend.ui.domain.login_register.AuthViewModel
+import com.example.happ_frontend.ui.domain.notifications.NotificationViewModel
 import com.example.happ_frontend.ui.domain.weight.WeightHistoryViewModel
 
 

--- a/app/src/main/java/com/example/happ_frontend/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/AppViewModelProvider.kt
@@ -1,5 +1,6 @@
 package com.example.happ_frontend.ui
 
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
@@ -22,15 +23,12 @@ object AppViewModelProvider{
         initializer {
             WeightHistoryViewModel(
                 weightHistoryRepository = happFrontendApplication().container.weightHistoryRepository,
-                weightHistoryApi = WeightHistoryNetworkModule.weightHistoryApiService
+                weightHistoryApi = WeightHistoryNetworkModule.weightHistoryApiService,
             )
         }
         initializer {
             AuthViewModel(
-                authApi = AuthNetworkModule.authApiService, // Direct access
-                prefs = AuthSharedPreferencesEditor(
-                    context = happFrontendApplication().applicationContext
-                )
+                authApi = AuthNetworkModule.authApiService,
             )
         }
     }

--- a/app/src/main/java/com/example/happ_frontend/ui/domain/login_register/AuthViewModel.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/domain/login_register/AuthViewModel.kt
@@ -1,8 +1,10 @@
 package com.example.happ_frontend.ui.domain.login_register
 
 import android.util.Log
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.happ_frontend.R
 import com.example.happ_frontend.model.login_register.Gender
 import com.example.happ_frontend.model.login_register.WeightDesire
 import com.example.happ_frontend.model.login_register.communication.AuthApiService
@@ -43,7 +45,12 @@ class AuthViewModel (
 
     sealed class ProfileState {
         data class Success(val username: String) : ProfileState()
-        data class Error(val message: String) : ProfileState()
+        data class Error(
+            @StringRes val messageResId: Int,
+            val formatArgs: List<Any> = emptyList(),
+            val fallbackMessage: String,
+            val isUnauthorizedError: Boolean,
+        ) : ProfileState()
         object Loading : ProfileState()
     }
 
@@ -212,7 +219,11 @@ class AuthViewModel (
                 if (response.isSuccessful) {
                     response.body()?.let { authResponse ->
                         prefs.username = data.value.username
-                        prefs.jwt = authResponse.jwt ?: ""
+                        prefs.jwt = authResponse.jwt
+                        Log.d(
+                            "AuthViewModel#login",
+                            "login success; username: ${prefs.username}, jwt: ${prefs.jwt}"
+                        )
                         _authState.value = AuthState.Success(authResponse.jwt ?: "")
                     }
                 } else {
@@ -225,14 +236,21 @@ class AuthViewModel (
     }
 
     fun checkAuth() {
-        viewModelScope.launch {
-            Log.d("AuthViewModel#checkAuth", "jwt is ${prefs.jwt}")
-            if (prefs.jwt == null) {
-                _profileState.value = ProfileState.Error("JWT is null")
-                prefs.clearUserData()
-                return@launch
-            }
+        Log.d("AuthViewModel#checkAuth", "jwt is ${prefs.jwt}")
+        if (prefs.jwt == null) {
+            _profileState.value = ProfileState.Error(
+                R.string.error_auth_noJwt,
+                fallbackMessage = "JWT is null",
+                isUnauthorizedError = true
+            )
+            prefs.clearUserData()
+            return
+        }
 
+        var isUnauthorizedError = false
+
+        viewModelScope.launch {
+            _profileState.value = ProfileState.Loading
             try {
                 val response = authApi.getUserInfo()
                 if (response.isSuccessful) {
@@ -242,24 +260,44 @@ class AuthViewModel (
                         username = it.username
                     }
                 } else {
-                    _profileState.value = ProfileState.Error("Session expired")
-                    prefs.clearUserData()
+                    if (response.code() == 401) {
+                        isUnauthorizedError = true
+                    }
+                    _profileState.value = ProfileState.Error(
+                        R.string.error_home_loadingError,
+                        fallbackMessage = "Error loading homepage",
+                        isUnauthorizedError = isUnauthorizedError
+                    )
                 }
             } catch (e: Exception) {
-                _profileState.value = ProfileState.Error("Network error: $e")
-                prefs.clearUserData()
+                _profileState.value = ProfileState.Error(
+                    R.string.error_misc_network_withMessage,
+                    formatArgs = listOf(e),
+                    fallbackMessage = "Error loading homepage due to network error: $e",
+                    isUnauthorizedError = true
+                )
+            } finally {
+                if (isUnauthorizedError) {
+                    prefs.clearUserData()
+                }
             }
         }
     }
 
-    fun clearAuthState() {
+    fun logoutUser() {
+        prefs.clearUserData()
         _authState.value = AuthState.Idle
+        _profileState.value = ProfileState.Error(
+            R.string.error_misc_unknown,
+            fallbackMessage = "Logged out",
+            isUnauthorizedError = true
+        )
     }
 }
 
-sealed class AuthState {
-    object Idle : AuthState()
-    object Loading : AuthState()
-    data class Success(val jwt: String) : AuthState()
-    data class Error(val message: String) : AuthState()
+sealed interface AuthState {
+    data object Idle : AuthState
+    data object Loading : AuthState
+    data class Success(val jwt: String) : AuthState
+    data class Error(val message: String) : AuthState
 }

--- a/app/src/main/java/com/example/happ_frontend/ui/domain/login_register/AuthViewModel.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/domain/login_register/AuthViewModel.kt
@@ -191,8 +191,8 @@ class AuthViewModel (
                 if (response.isSuccessful) {
                     response.body()?.let { authResponse ->
                         prefs.username = data.value.username
-                        prefs.jwt = authResponse.jwt ?: ""
-                        _authState.value = AuthState.Success(authResponse.jwt ?: "")
+                        prefs.jwt = authResponse.jwt
+                        _authState.value = AuthState.Success(authResponse.jwt)
                     }
                 } else {
                     _authState.value = AuthState.Error("Server error: ${response.code()}")
@@ -224,7 +224,7 @@ class AuthViewModel (
                             "AuthViewModel#login",
                             "login success; username: ${prefs.username}, jwt: ${prefs.jwt}"
                         )
-                        _authState.value = AuthState.Success(authResponse.jwt ?: "")
+                        _authState.value = AuthState.Success(authResponse.jwt)
                     }
                 } else {
                     _authState.value = AuthState.Error("Server error: ${response.code()}")

--- a/app/src/main/java/com/example/happ_frontend/ui/domain/weight/WeightHistoryViewModel.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/domain/weight/WeightHistoryViewModel.kt
@@ -210,7 +210,7 @@ class WeightHistoryViewModel(
 
         @StringRes
         var errorMessageRes: Int? = null
-        var isUnauthorizedError: Boolean = false
+        var isUnauthorizedError = false
 
         viewModelScope.launch {
             try {

--- a/app/src/main/java/com/example/happ_frontend/ui/domain/weight/WeightHistoryViewModel.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/domain/weight/WeightHistoryViewModel.kt
@@ -1,24 +1,24 @@
 package com.example.happ_frontend.ui.domain.weight
 
-import android.net.http.NetworkException
 import android.util.Log
+import androidx.annotation.StringRes
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.happ_frontend.R
+import com.example.happ_frontend.model.login_register.data.AuthSharedPreferencesEditor
+import com.example.happ_frontend.model.login_register.data.AuthSharedPreferencesProvider
 import com.example.happ_frontend.model.login_register.request.UserDataDto
 import com.example.happ_frontend.model.weight.WeightCalendarEvent
 import com.example.happ_frontend.model.weight.communication.WeightHistoryApiService
 import com.example.happ_frontend.model.weight.communication.WeightHistoryNetworkModule
 import com.example.happ_frontend.model.weight.data.WeightHistoryRepository
 import com.example.happ_frontend.model.weight.kg
-import com.example.happ_frontend.ui.domain.login_register.AuthState
 import com.example.happ_frontend.ui.domain.login_register.AuthValidationResult
 import com.example.happ_frontend.ui.domain.login_register.AuthValidator
-import com.example.happ_frontend.ui.domain.login_register.now
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,7 +35,9 @@ import kotlin.reflect.KProperty
  */
 class WeightHistoryViewModel(
     private val weightHistoryRepository: WeightHistoryRepository,
-    private val weightHistoryApi: WeightHistoryApiService = WeightHistoryNetworkModule.weightHistoryApiService
+    private val weightHistoryApi: WeightHistoryApiService = WeightHistoryNetworkModule.weightHistoryApiService,
+    private val authPrefs: AuthSharedPreferencesEditor = AuthSharedPreferencesProvider.editor
+        ?: throw IllegalStateException("AuthSharedPreferencesEditor not initialized yet"),
 ): ViewModel() {
     private val _weightEvents = mutableStateListOf<WeightCalendarEvent>()
     val weightEvents get() = _weightEvents.toList()
@@ -50,7 +52,11 @@ class WeightHistoryViewModel(
     sealed interface WeightHistoryState {
         data object Loading: WeightHistoryState
         data object Success: WeightHistoryState
-        data class Failure(val message: String): WeightHistoryState
+        data class Failure(
+            @StringRes val messageRes: Int,
+            val formatArgs: List<Any> = emptyList(),
+            val isUnauthorizedError: Boolean = false
+        ): WeightHistoryState
     }
 
     var formShown by mutableStateOf(false)
@@ -134,6 +140,18 @@ class WeightHistoryViewModel(
     }
 
     fun fetchWeightHistoryFromServer() {
+        Log.d("WeightHistoryViewModel#addWeightHistoryEvent", "jwt: ${authPrefs.jwt}")
+        if (authPrefs.jwt == null) {
+            _weightHistoryState.value = WeightHistoryState.Failure(
+                R.string.error_auth_noJwt,
+                isUnauthorizedError = true
+            )
+            authPrefs.clearUserData()
+            return
+        }
+
+        var isUnauthorizedError = false
+
         viewModelScope.launch {
             _weightHistoryState.value = WeightHistoryState.Loading
             try {
@@ -155,28 +173,55 @@ class WeightHistoryViewModel(
                         }
                     }
                 } else {
+                    if (response.code() == 401) {
+                        isUnauthorizedError = true
+                    }
+
                     _weightHistoryState.value = WeightHistoryState.Failure(
-                        "Failed to load weight history data."
+                        R.string.error_weight_weightHistory_loadFail,
+                        isUnauthorizedError = isUnauthorizedError
                     )
                     _weightEvents.clear()
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
-                _weightHistoryState.value = WeightHistoryState.Failure(
-                    e.message ?: "Unknown error"
-                )
+                _weightHistoryState.value = e.message?.let { msg ->
+                    WeightHistoryState.Failure(R.string.error_misc_errorPrefix, formatArgs = listOf(msg))
+                } ?: WeightHistoryState.Failure(R.string.error_misc_unknown)
                 _weightEvents.clear()
+            } finally {
+                if (isUnauthorizedError) {
+                    authPrefs.clearUserData()
+                }
             }
         }
     }
 
     fun addWeightHistoryEvent(weight: Float) {
+        Log.d("WeightHistoryViewModel#addWeightHistoryEvent", "jwt: ${authPrefs.jwt}")
+        if (authPrefs.jwt == null) {
+            _weightHistoryState.value = WeightHistoryState.Failure(
+                R.string.error_auth_noJwt,
+                isUnauthorizedError = true
+            )
+            authPrefs.clearUserData()
+            return
+        }
+
+        @StringRes
+        var errorMessageRes: Int? = null
+        var isUnauthorizedError: Boolean = false
+
         viewModelScope.launch {
             try {
                 _weightHistoryState.value = WeightHistoryState.Loading
                 val userInfoResponse = weightHistoryApi.getUserInfo()
                 if (!userInfoResponse.isSuccessful) {
-                    throw IllegalArgumentException("Failed to load user data.")
+                    errorMessageRes = R.string.error_weight_userData_loadFail
+                    if (userInfoResponse.code() == 401) {
+                        isUnauthorizedError = true
+                    }
+                    throw IllegalArgumentException()
                 }
                 userInfoResponse.body()?.let { userDataResponseBody ->
                     val userDataRequest = UserDataDto
@@ -184,16 +229,26 @@ class WeightHistoryViewModel(
                         .copy(weight = weight)
                     val updateUserInfoResponse = weightHistoryApi.updateInfo(userDataRequest)
                     if (!updateUserInfoResponse.isSuccessful) {
-                        throw IllegalArgumentException("Failed to update user data.")
+                        errorMessageRes = R.string.error_weight_userData_updateFail
+                        throw IllegalArgumentException()
                     }
                     fetchWeightHistoryFromServer()
-                } ?: throw IllegalArgumentException("The user data fetched was null.")
+                }
+                if (userInfoResponse.body() == null) {
+                    errorMessageRes = R.string.error_weight_userData_loadFail
+                    throw IllegalArgumentException()
+                }
             } catch (e: Exception) {
                 e.printStackTrace()
                 _weightHistoryState.value = WeightHistoryState.Failure(
-                    e.message ?: "Unknown error"
+                    errorMessageRes ?: R.string.error_misc_unknown,
+                    isUnauthorizedError = isUnauthorizedError
                 )
                 _weightEvents.clear()
+            } finally {
+                if (isUnauthorizedError) {
+                    authPrefs.clearUserData()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/happ_frontend/ui/navigation/HappFrontendNavigationHost.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/navigation/HappFrontendNavigationHost.kt
@@ -5,12 +5,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import androidx.navigation.NavOptions
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.navOptions
 import com.example.happ_frontend.ui.screens.home.HomeScreen
 import com.example.happ_frontend.ui.screens.login_register.LoginScreen
 import com.example.happ_frontend.ui.screens.login_register.RegisterScreen

--- a/app/src/main/java/com/example/happ_frontend/ui/navigation/HappFrontendNavigationHost.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/navigation/HappFrontendNavigationHost.kt
@@ -7,8 +7,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navOptions
 import com.example.happ_frontend.ui.screens.home.HomeScreen
 import com.example.happ_frontend.ui.screens.login_register.LoginScreen
 import com.example.happ_frontend.ui.screens.login_register.RegisterScreen
@@ -20,6 +22,10 @@ fun HappFrontendNavigationHost(
     navigationController: NavHostController,
     modifier: Modifier = Modifier
 ) {
+    navigationController.addOnDestinationChangedListener { controller, dest, bundle ->
+        Log.d("HappFrontendNavigationHost", "Navigated to ${dest.route}")
+    }
+
     Scaffold { innerPadding ->
         NavHost(
             modifier = modifier.padding(innerPadding),
@@ -32,18 +38,20 @@ fun HappFrontendNavigationHost(
             composable(route = LoginDest.route) {
                 LoginScreen(
                     onNavigateToRegister = { navigationController.navigate(RegisterDest.route) },
-                    onNavigateToHome = { navigationController.navigate(HomeDest.route) }
+                    onNavigateToHome = { navigationController.navigateAndClear(HomeDest.route) }
                 )
             }
             composable(route = RegisterDest.route) {
                 RegisterScreen(
-                    onNavigateToHome = { navigationController.navigate(HomeDest.route) },
+                    onNavigateToHome = { navigationController.navigateAndClear(HomeDest.route) },
                     onNavigateToLogin = { navigationController.navigate(LoginDest.route) }
                 )
             }
             composable(route = HomeDest.route) {
                 HomeScreen(
-                    onNavigateToLogin = { navigationController.navigate(LoginDest.route) },
+                    onUnauthorized = {
+                        navigationController.navigateAndClear(LoginDest.route)
+                    },
                     onNavigateToWeightHistory = {
                         navigationController.navigate(WeightHistoryDest.route)
                     },
@@ -60,10 +68,34 @@ fun HappFrontendNavigationHost(
             composable(route = WeightHistoryDest.route) {
                 WeightHistoryScreen(
                     onGoBack = {
-                        navigationController.navigate(HomeDest.route)
+                        navigationController.popBackStack(
+                            route = WeightHistoryDest.route,
+                            inclusive = true
+                        )
+                    },
+                    onUnauthorized = {
+                        navigationController.navigateAndClear(LoginDest.route)
                     }
                 )
             }
          }
+    }
+}
+
+/**
+ * Navigates to the destination route and attempts to pop back stack up to the current route
+ * (inclusive).
+ *
+ * @param destinationRoute Destination route to navigate to
+ * @author Vad1mChK
+ */
+fun NavHostController.navigateAndClear(destinationRoute: String) {
+    val currentRoute = this.currentDestination?.route
+    this.navigate(destinationRoute) {
+        currentRoute?.let {
+            popUpTo(it) {
+                inclusive = true
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/happ_frontend/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/screens/home/HomeScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -37,7 +36,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.happ_frontend.R
 import com.example.happ_frontend.ui.AppViewModelProvider
 import com.example.happ_frontend.ui.domain.login_register.AuthViewModel
-import com.example.happ_frontend.ui.domain.login_register.capitalize
 
 /**
  * Composable function that represents the main screen of the application.

--- a/app/src/main/java/com/example/happ_frontend/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/screens/home/HomeScreen.kt
@@ -17,8 +17,12 @@ import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -33,6 +37,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.happ_frontend.R
 import com.example.happ_frontend.ui.AppViewModelProvider
 import com.example.happ_frontend.ui.domain.login_register.AuthViewModel
+import com.example.happ_frontend.ui.domain.login_register.capitalize
 
 /**
  * Composable function that represents the main screen of the application.
@@ -42,7 +47,7 @@ import com.example.happ_frontend.ui.domain.login_register.AuthViewModel
 @Composable
 fun HomeScreen(
     viewModel: AuthViewModel = viewModel(factory = AppViewModelProvider.Factory),
-    onNavigateToLogin: () -> Unit = {},
+    onUnauthorized: () -> Unit = {},
     onNavigateToWeightHistory: () -> Unit = {},
     onNavigateToNutrition: () -> Unit = {},
     onNavigateToActivity: () -> Unit = {},
@@ -73,8 +78,41 @@ fun HomeScreen(
         }
         is AuthViewModel.ProfileState.Error -> {
             LaunchedEffect(state) {
-                Log.d("HomeScreen", "Error: ${state.message}")
-                onNavigateToLogin()
+                Log.d("HomeScreen", "Error loading home page: ${state.fallbackMessage}")
+            }
+            if (state.isUnauthorizedError) {
+                onUnauthorized()
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(all = 32.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        stringResource(
+                            id = state.messageResId,
+                            formatArgs = state.formatArgs.toTypedArray()
+                        )
+                    )
+                    Button(
+                        onClick = viewModel::checkAuth,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.dialog_misc_buttons_retry).uppercase())
+                    }
+                    Button(
+                        onClick = viewModel::logoutUser,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    ) {
+                        Text(stringResource(R.string.auth_button_logout).uppercase())
+                    }
+                }
             }
         }
         is AuthViewModel.ProfileState.Loading -> {

--- a/app/src/main/java/com/example/happ_frontend/ui/screens/weight/WeightHistoryScreen.kt
+++ b/app/src/main/java/com/example/happ_frontend/ui/screens/weight/WeightHistoryScreen.kt
@@ -1,6 +1,5 @@
 package com.example.happ_frontend.ui.screens.weight
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -28,25 +27,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavHostController
 import com.example.happ_frontend.R
 import com.example.happ_frontend.ui.domain.login_register.format
-import com.example.happ_frontend.ui.domain.login_register.now
-import com.example.happ_frontend.model.weight.WeightCalendarEvent
 import com.example.happ_frontend.ui.domain.weight.WeightHistoryViewModel
-import com.example.happ_frontend.model.weight.kg
 import com.example.happ_frontend.ui.AppViewModelProvider
-import com.example.happ_frontend.ui.domain.login_register.AuthState
 import com.example.happ_frontend.ui.domain.weight.WeightHistoryFormData
-import com.example.happ_frontend.ui.domain.weight.minus
-import com.example.happ_frontend.ui.domain.weight.plus
 import com.example.happ_frontend.ui.screens.home.HealthCategoryWidget
 import kotlinx.datetime.daysUntil
-import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toKotlinLocalDate
-import kotlinx.datetime.toKotlinLocalDateTime
 import java.time.LocalDate
-import java.time.LocalDateTime
 import kotlin.math.abs
 
 /**
@@ -62,6 +51,7 @@ import kotlin.math.abs
 @Composable
 fun WeightHistoryScreen(
     onGoBack: () -> Unit = {},
+    onUnauthorized: () -> Unit = {},
     viewModel: WeightHistoryViewModel = viewModel(factory = AppViewModelProvider.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -79,7 +69,8 @@ fun WeightHistoryScreen(
         if (state is WeightHistoryViewModel.WeightHistoryState.Failure) {
             Toast.makeText(
                 context,
-                "Error: ${state.message}", Toast.LENGTH_LONG
+                context.getString(state.messageRes, *state.formatArgs.toTypedArray()),
+                Toast.LENGTH_LONG
             ).show()
         }
     }
@@ -177,10 +168,13 @@ fun WeightHistoryScreen(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
+                        if (state.isUnauthorizedError) {
+                            onUnauthorized()
+                        }
                         Text(
                             stringResource(
                                 R.string.health_category_weight_widget_failure,
-                                state.message
+                                stringResource(state.messageRes, *state.formatArgs.toTypedArray())
                             )
                         )
                         Button(onClick = { viewModel.fetchWeightHistoryFromServer() }) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -38,12 +38,14 @@
     <string name="auth.button.register">Зарегистрироваться</string>
     <string name="dialog.misc.buttons.ok">ОК</string>
     <string name="dialog.misc.buttons.cancel">Отмена</string>
+    <string name="dialog.misc.buttons.retry">Повторить</string>
     <string name="dialog.datepicker.header">Выберите дату</string>
     <string name="biom.weight_desire">Пожелания по весу</string>
     <string name="biom.weight_desire.loss">Сбросить вес</string>
     <string name="biom.weight_desire.remain">Сохранить вес</string>
     <string name="auth.hint.already_have_account">Уже есть аккаунт?</string>
     <string name="auth.hint.forgot_password.condolence">Соболезнуем.</string>
+    <string name="auth.button.logout">Выйти</string>
     <string name="auth.valid_error.username.length">Никнейм должен быть не короче %1$d символов</string>
     <string name="auth.valid_error.username.regex">Никнейм может содержать только буквы, цифры, подчёркивание, и должен начинаться не с цифры</string>
     <string name="auth.valid_error.password.length">Пароль должен быть не короче %1$d символов</string>
@@ -71,6 +73,7 @@
     <string name="health_category.weight.dialog.title">Новая запись о весе</string>
     <string name="health_category.weight.dialog.field.date">Дата записи</string>
     <string name="health.category.weight.dialog.field.time">Время записи</string>
+    <string name="error.weight.weightHistory.loadFail">Не удалось загрузить историю весов</string>
     <string name="notifications">Уведомления</string>
     <string name="activityNotification">Activity</string>
     <string name="friendNotification">Заявка в друзья</string>
@@ -84,4 +87,14 @@
     <string name="achievements">Достижения</string>
     <string name="delete_all_notifications">Удалить все уведомления</string>
     <string name="health.category.weight.widget.failure">Не удалось загрузить историю весов. Причина: %1$s</string>
+    <string name="error.misc.errorPrefix">Ошибка: %1$s</string>
+    <string name="error.misc.unknown">Неизвестная ошибка</string>
+    <string name="error.misc.network">Ошибка сети</string>
+    <string name="error.misc.network.withMessage">Ошибка сети: %1$s</string>
+    <string name="error.auth.noJwt">JWT не установлен, войдите снова</string>
+    <string name="error.auth.unauthorized">Ошибка авторизации</string>
+    <string name="error.home.loadingError">Ошибка загрузки главного экрана.</string>
+    <string name="error.home.loadingError.withMessage">Ошибка загрузки главного экрана: %1$s</string>
+    <string name="error.weight.userData.loadFail">Не удалось загрузить данные пользователя</string>
+    <string name="error.weight.userData.updateFail">Не удалось обновить данные пользователя</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="auth.button.login">Login</string>
     <string name="auth.button.register">Register</string>
     <string name="auth.button.register_continue">Continue</string>
+    <string name="auth.button.logout">Logout</string>
     <string name="auth.valid_error.username.length">Username must be at least %1$d characters long</string>
     <string name="auth.valid_error.username.regex">Username can only contain letters, numbers, underscores, and must start with a letter</string>
     <string name="auth.valid_error.password.length">Password must be at least %1$d characters long</string>
@@ -84,11 +85,26 @@
     <!--Dialogs -->
     <string name="dialog.misc.buttons.ok">OK</string>
     <string name="dialog.misc.buttons.cancel">Cancel</string>
+    <string name="dialog.misc.buttons.retry">Retry</string>
     <string name="dialog.datepicker.header">Select date</string>
     <!-- etc. -->
 
     <!-- User profile -->
     <string name="user.profile.hi">Hi, </string>
+    <!-- etc. -->
+
+    <!-- Server communication errors -->
+    <string name="error.misc.errorPrefix">Error: %1$s</string>
+    <string name="error.misc.unknown">Unknown error</string>
+    <string name="error.misc.network">Network error</string>
+    <string name="error.misc.network.withMessage">Network error: %1$s</string>
+    <string name="error.auth.noJwt">JWT is not set, have to log in again</string>
+    <string name="error.auth.unauthorized">Authorization error</string>
+    <string name="error.home.loadingError">There was an error loading the home screen.</string>
+    <string name="error.home.loadingError.withMessage">Error loading home screen: %1$s</string>
+    <string name="error.weight.userData.loadFail">Failed to load user data</string>
+    <string name="error.weight.userData.updateFail">Failed to update user data</string>
+    <string name="error.weight.weightHistory.loadFail">Failed to load weight history</string>
     <!-- etc. -->
 
     <!-- Everything to do with notifications -->


### PR DESCRIPTION
- [x] `onUnauthorized` callback for all except Login and Register, it should be called when response.code() == 401
- [x] "pop" stack on return from WeightHistory to Home so that, on clicking Back you won't be able to return to WeightHistory
- [x] on clicking Back many times you should not be able to go beyond Login (when unauthorized) or Home (when authorized)
- [x] add localization strings for displayed error messages
- [x] check that jwt is passed everywhere

### Перед review кода:
- [x] Код соответствует языковому стилю, [принятому в языке Kotlin](https://kotlinlang.org/docs/coding-conventions.html).
- [x] Линтер не фиксирует ошибок и предупреждений в коде.
- [ ] Сообщения коммитов соответствуют соглашениям проекта.
- [ ] Написаны и успешно проходят модульные тесты.
- [x] Я протестировал код локально, ошибок не обнаружено.
- [ ] Я задокументировал все неочевидные моменты в обсуждении задачи.

### Перед merge'м:
- [ ] Код рассмотрен и одобрен лидером команды, все замечания устранены.
- [x] Я сделал backmerge целевой ветки, конфликты слияния устранены.
- [ ] Я обновил changelog своей части Frontend.
- [x] Я сообщил о предстоящем слиянии.